### PR TITLE
Give the s3 proxy a separate region config

### DIFF
--- a/contexts/IContext.ts
+++ b/contexts/IContext.ts
@@ -44,6 +44,7 @@ export interface S3Proxy {
   dockerImage:          string;
   bucketUserSecretName: string;
   OLAP:                 string;
+  region:               string;
 }
 
 export interface Tags {

--- a/lib/WordpressS3ProxyContainerDefConfig.ts
+++ b/lib/WordpressS3ProxyContainerDefConfig.ts
@@ -17,7 +17,7 @@ export class WordpressS3ProxyContainerDefConfig {
       scope, 'bucket-secret',  scope.context.S3PROXY.bucketUserSecretName
     );
     
-    const host=`${scope.context.S3PROXY.OLAP}.${olap_service}.${scope.context.REGION}.amazonaws.com`;
+    const host=`${scope.context.S3PROXY.OLAP}.${olap_service}.${scope.context.S3PROXY.region}.amazonaws.com`;
     const prfx = this.prefix || scope.id;
     const { HOST_PORT:hostPort, HOST_PORT:containerPort } = WordpressS3ProxyContainerDefConfig;
 
@@ -36,7 +36,7 @@ export class WordpressS3ProxyContainerDefConfig {
         '-v',
         '--name', 's3-object-lambda',
         '--host', host,
-        '--region', scope.context.REGION,
+        '--region', scope.context.S3PROXY.region,
         '--no-verify-ssl'
       ],
       portMappings: [{


### PR DESCRIPTION
This enables the use of an object lambda access point that is in a different region from the ecs cluster.
