### PR TITLE
Adding WP_ENVIRONMENT_TYPE to WordPress container configuration

### DIFF
--- a/context/IContext.ts
+++ b/context/IContext.ts
@@ -72,6 +72,7 @@ export interface WordpressEnv {
   dbName?:           string;
   dbPort?:           string;
   debug?:            any;
+  environmentType?:  string;
 }
 
 export interface WordpressSecret {

--- a/context/context.json
+++ b/context/context.json
@@ -35,7 +35,8 @@
         "debug": "0",
         "dbType": "serverless",
         "dbUser": "root",
-        "dbName": "wp_db"
+        "dbName": "wp_db",
+        "environmentType": "development"
       },
       "secret": {
         "wpSecretArn": "arn:aws:secretsmanager:us-east-2:770203350335:secret:wp/devl1-19LH5c",

--- a/lib/WordpressAppContainerDefConfig.ts
+++ b/lib/WordpressAppContainerDefConfig.ts
@@ -60,6 +60,7 @@ export class WordpressAppContainerDefConfig {
       dbName:WORDPRESS_DB_NAME=DEFAULT_DB_NAME, 
       dbHost:WORDPRESS_DB_HOST=getRdsHost(),
       debug='0', // Default to debug off
+      environmentType:WP_ENVIRONMENT_TYPE='production',
     } = wp.env;
     const WORDPRESS_DEBUG = `${debug}`;
     const WP_CLI_ALLOW_ROOT = 'true';
@@ -89,7 +90,8 @@ export class WordpressAppContainerDefConfig {
       }),
       environment: { 
         SP_ENTITY_ID, IDP_ENTITY_ID, TZ, S3PROXY_HOST, WORDPRESS_DB_HOST,
-        WORDPRESS_DB_USER, WORDPRESS_DB_NAME, WORDPRESS_DEBUG, WP_CLI_ALLOW_ROOT
+        WORDPRESS_DB_USER, WORDPRESS_DB_NAME, WORDPRESS_DEBUG, WP_CLI_ALLOW_ROOT,
+        WP_ENVIRONMENT_TYPE
       },
       // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html
       secrets: {


### PR DESCRIPTION
## Adds `WP_ENVIRONMENT_TYPE` to the ECS container configuration

This threads the WordPress-native [`WP_ENVIRONMENT_TYPE`](https://developer.wordpress.org/reference/functions/wp_get_environment_type/) environment variable through the CDK stack, making it available to the WordPress container at runtime.

### Why this matters

WordPress core provides `wp_get_environment_type()` as the standard way for plugins and themes to detect their runtime environment. The accepted values are `local`, `development`, `staging`, and `production`.

The immediate consumer is `bu-core`, which now uses this to conditionally generate a restrictive `robots.txt` on non-production environments — preventing search engines from indexing staging and development content replicas. See the [consumer implementation in bu-core](https://github.com/bu-ist/bu-core/blob/379aafec67337af458ac462b25a9ced474f6b209/src/wp-cli.php#L113-L122) (from [bu-ist/bu-core#35](https://github.com/bu-ist/bu-core/pull/35)).

Without this variable set in the ECS container environment, the WordPress application lacks this standard mechanism to distinguish a dev/staging cluster from production.

### What this changes

- Adds `environmentType` to the `WordpressEnv` interface in `IContext.ts`
- Destructures it as `WP_ENVIRONMENT_TYPE` with a default of `'production'` in `WordpressAppContainerDefConfig.ts` (safe default — matches WordPress's own behavior when the variable is unset)
- Sets `'development'` in the default `context.json` (which targets the devl1 landscape)

Production deployments can either omit the field (getting the `'production'` default) or set it explicitly in their context file.